### PR TITLE
Csproj breaking changes

### DIFF
--- a/Csg.PerfTest/Csg.PerfTest.csproj
+++ b/Csg.PerfTest/Csg.PerfTest.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <ProjectReference Include="..\Csg\Csg.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Csg/Csg.csproj
+++ b/Csg/Csg.csproj
@@ -16,7 +16,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     
     <LangVersion>8.0</LangVersion>
-    <NullableReferenceTypes>true</NullableReferenceTypes>
+    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>1701;1702;1591</NoWarn>

--- a/Csg/Polygon.cs
+++ b/Csg/Polygon.cs
@@ -106,8 +106,8 @@ namespace Csg
 				return tag;
 			}
 		}
-		public PolygonShared(object color)
-		{			
+		public PolygonShared(object? color)
+		{
 		}
 		public string Hash
 		{

--- a/Csg/Tree.cs
+++ b/Csg/Tree.cs
@@ -198,7 +198,7 @@ namespace Csg
 
 					for (int i = 0, n = polygontreenodes.Count; i < n; i++)
 					{
-						polygontreenodes[i].SplitByPlane(_thisPlane, ref _this.PolygonTreeNodes, ref backnodes, ref frontnodes, ref backnodes);
+						polygontreenodes[i].SplitByPlane(_thisPlane, ref _this.PolygonTreeNodes!, ref backnodes, ref frontnodes, ref backnodes);
 					}
 
 					if (frontnodes != null && frontnodes.Count > 0)


### PR DESCRIPTION
<NullableReferenceTypes /> property was deprecated in favour of <Nullable />, The property is no longer supported by the compiler.

Reference: https://stackoverflow.com/questions/53633538/how-to-enable-nullable-reference-types-feature-of-c-sharp-8-0-for-the-whole-proj

----

BenchmarkDotNet 0.11.x is not compatible with the above.