### PR TITLE
Increase supported axis range from -21475 .. 21475 to -92_233_720_368…

### DIFF
--- a/Csg/Solid.cs
+++ b/Csg/Solid.cs
@@ -948,11 +948,11 @@ namespace Csg
 		public Vertex LookupOrCreate (ref Vertex vertex)
 		{
 			var key = new Key {
-				X = (int)(vertex.Pos.X * multiplier + 0.5),
-				Y = (int)(vertex.Pos.Y * multiplier + 0.5),
-				Z = (int)(vertex.Pos.Z * multiplier + 0.5),
-				U = (int)(vertex.Tex.X * multiplier + 0.5),
-				V = (int)(vertex.Tex.Y * multiplier + 0.5),
+				X = (long)(vertex.Pos.X * multiplier + 0.5),
+				Y = (long)(vertex.Pos.Y * multiplier + 0.5),
+				Z = (long)(vertex.Pos.Z * multiplier + 0.5),
+				U = (long)(vertex.Tex.X * multiplier + 0.5),
+				V = (long)(vertex.Tex.Y * multiplier + 0.5),
 			};
 			if (lookuptable.TryGetValue (key, out var v))
 				return v;
@@ -961,7 +961,7 @@ namespace Csg
 		}
 		struct Key
 		{
-			public int X, Y, Z, U, V;
+			public long X, Y, Z, U, V;
 		}
 		class KeyComparer : IEqualityComparer<Key>
 		{
@@ -995,10 +995,10 @@ namespace Csg
 		public Plane LookupOrCreate (Plane plane)
 		{
 			var key = new Key {
-				X = (int)(plane.Normal.X * multiplier + 0.5),
-				Y = (int)(plane.Normal.Y * multiplier + 0.5),
-				Z = (int)(plane.Normal.Z * multiplier + 0.5),
-				W = (int)(plane.W * multiplier + 0.5),
+				X = (long)(plane.Normal.X * multiplier + 0.5),
+				Y = (long)(plane.Normal.Y * multiplier + 0.5),
+				Z = (long)(plane.Normal.Z * multiplier + 0.5),
+				W = (long)(plane.W * multiplier + 0.5),
 			};
 			if (lookuptable.TryGetValue (key, out var p))
 				return p;
@@ -1007,7 +1007,7 @@ namespace Csg
 		}
 		struct Key
 		{
-			public int X, Y, Z, W;
+			public long X, Y, Z, W;
 		}
 		class KeyComparer : IEqualityComparer<Key>
 		{


### PR DESCRIPTION
The axis are currently limited to a range of -21475 to 21475. Adding a vertex with a dimension outside of this range results in an overflow during a union operation and a malformed result.

[Results.zip](https://github.com/praeclarum/Csg/files/7073956/Results.zip)
