### PR TITLE
Throw exception on double overflow to avoid infinite loop

### DIFF
--- a/Csg/Vector.cs
+++ b/Csg/Vector.cs
@@ -8,6 +8,10 @@ namespace Csg
 
 		public Vector3D(double x, double y, double z)
 		{
+			if (double.IsNaN(x)) throw new ArgumentOutOfRangeException (nameof(x), "Value is NaN");
+			if (double.IsNaN(y)) throw new ArgumentOutOfRangeException (nameof(y), "Value is NaN");
+			if (double.IsNaN(z)) throw new ArgumentOutOfRangeException (nameof(z), "Value is NaN");
+
 			X = x;
 			Y = y;
 			Z = z;


### PR DESCRIPTION
A Vector3D with a NaN axis results in an in infinite loop during a union operation.

A NaN value is achievable by constructing a cube with a sufficiently large centre/radius value.